### PR TITLE
Library

### DIFF
--- a/s-with-me-front/src/App.js
+++ b/s-with-me-front/src/App.js
@@ -6,11 +6,11 @@ import configureStore from './store/configureStore';
 
 import NotFound from './components/NotFound';
 import LoginApp from './components/LoginApp';
-import LibraryApp from './components/student/libarary/LibraryApp';
 import BookDetail from './components/student/libarary/BookDetail';
 import ProblemApp from './components/student/problem/ProblemApp';
 import NoteApp from './components/student/note/NoteApp';
 import SignUpInputContainer from './containers/student/signUp/SignUpInputContainer';
+import LibraryAppContainer from './containers/student/book/LibraryAppContainer';
 
 export default class App extends PureComponent {
   store = configureStore();
@@ -22,7 +22,7 @@ export default class App extends PureComponent {
           <Switch>
             <Route path="/" exact render={() => <LoginApp />} />
             <Route path="/signup" exact render={() => <SignUpInputContainer />} />
-            <Route path="/library" exact render={() => <LibraryApp />} />
+            <Route path="/library" exact render={() => <LibraryAppContainer />} />
             <Route
               path="/library/myBook/:myBookId"
               exact

--- a/s-with-me-front/src/actions/myBookActions.js
+++ b/s-with-me-front/src/actions/myBookActions.js
@@ -1,57 +1,6 @@
-import Api from '../Api';
-
-export const LOADING_MY_BOOK_LIST = 'myBook/LOADING_MY_BOOK_LIST';
-export const SET_MY_BOOK_LIST = 'myBook/SET_MY_BOOK_LIST';
 export const SET_LAST_MY_PROBLEM = 'myBook/SET_LAST_MY_PROBLEM';
-export const SET_ERROR = 'myBook/SET_ERROR';
-export const SOLVE_COMPLETE = 'myBook/SOLVE_COMPLETE';
-
-export function loading() {
-  return {
-    type: LOADING_MY_BOOK_LIST,
-  };
-}
-
-export function setError(errorMessage) {
-  return {
-    type: SET_ERROR,
-    payload: { errorMessage },
-  };
-}
-export const setmyBookList = (myBookList) => ({
-  type: SET_MY_BOOK_LIST,
-  payload: myBookList,
-});
-
-export function requestMyBookList(params) {
-  console.log('...');
-  return (dispatch) => {
-    dispatch(loading());
-    Api.get('/student/library', { params: params }).then(
-      ({ data }) => dispatch(setmyBookList(data)),
-      (error) => {
-        dispatch(setError(error.response.data.errorMessage));
-      },
-    );
-  };
-}
 
 export const setLastMyProblem = (id, lastMyProblemId) => ({
   type: SET_LAST_MY_PROBLEM,
   payload: { id, lastMyProblemId },
 });
-
-export function solveComplete() {
-  return { type: SOLVE_COMPLETE };
-}
-
-// export function createMyBookData(myBookId, data, onComplete) {
-//   return (dispatch) =>
-//     Api.put(`/student/library/my-book/my-problems/${myBookId}`, data).then(
-//       ({ data }) => {
-//         dispatch(solveComplete());
-//         onComplete();
-//       },
-//       (error) => dispatch(setError(error.response.data.message)),
-//     );
-// }

--- a/s-with-me-front/src/actions/myBookActions.js
+++ b/s-with-me-front/src/actions/myBookActions.js
@@ -1,0 +1,57 @@
+import Api from '../Api';
+
+export const LOADING_MY_BOOK_LIST = 'myBook/LOADING_MY_BOOK_LIST';
+export const SET_MY_BOOK_LIST = 'myBook/SET_MY_BOOK_LIST';
+export const SET_LAST_MY_PROBLEM = 'myBook/SET_LAST_MY_PROBLEM';
+export const SET_ERROR = 'myBook/SET_ERROR';
+export const SOLVE_COMPLETE = 'myBook/SOLVE_COMPLETE';
+
+export function loading() {
+  return {
+    type: LOADING_MY_BOOK_LIST,
+  };
+}
+
+export function setError(errorMessage) {
+  return {
+    type: SET_ERROR,
+    payload: { errorMessage },
+  };
+}
+export const setmyBookList = (myBookList) => ({
+  type: SET_MY_BOOK_LIST,
+  payload: myBookList,
+});
+
+export function requestMyBookList(params) {
+  console.log('...');
+  return (dispatch) => {
+    dispatch(loading());
+    Api.get('/student/library', { params: params }).then(
+      ({ data }) => dispatch(setmyBookList(data)),
+      (error) => {
+        dispatch(setError(error.response.data.errorMessage));
+      },
+    );
+  };
+}
+
+export const setLastMyProblem = (id, lastMyProblemId) => ({
+  type: SET_LAST_MY_PROBLEM,
+  payload: { id, lastMyProblemId },
+});
+
+export function solveComplete() {
+  return { type: SOLVE_COMPLETE };
+}
+
+// export function createMyBookData(myBookId, data, onComplete) {
+//   return (dispatch) =>
+//     Api.put(`/student/library/my-book/my-problems/${myBookId}`, data).then(
+//       ({ data }) => {
+//         dispatch(solveComplete());
+//         onComplete();
+//       },
+//       (error) => dispatch(setError(error.response.data.message)),
+//     );
+// }

--- a/s-with-me-front/src/actions/myBookPackActions.js
+++ b/s-with-me-front/src/actions/myBookPackActions.js
@@ -1,0 +1,29 @@
+import Api from '../Api';
+
+export const FETCH_MY_BOOK_LIST = 'myBook/FETCH_MY_BOOK_LIST';
+export const UPDATE_LAST_PROBLEM_ID = 'myBook/UPDATE_LAST_PROBLEM_ID';
+
+export function requestMyBookList(params) {
+  return {
+    type: FETCH_MY_BOOK_LIST,
+    promise: Api.get('/student/library', { params: params }),
+    meta: {
+      notification: {
+        error: '문제집을 불러오는 중에 문제가 발생했습니다.',
+      },
+    },
+  };
+}
+
+export function updateLastProblemId(id, data, onComplete) {
+  return {
+    type: UPDATE_LAST_PROBLEM_ID,
+    // promise: Api.put('', data),
+    meta: {
+      onSuccess: onComplete,
+      notification: {
+        success: '마지막으로 푼 문제가 성공적으로 저장되었습니다.',
+      },
+    },
+  };
+}

--- a/s-with-me-front/src/components/student/libarary/BookOverview.jsx
+++ b/s-with-me-front/src/components/student/libarary/BookOverview.jsx
@@ -4,7 +4,17 @@ import PropTypes from 'prop-types';
 import InlineList from '../../../common-ui/InlineList';
 import BookPreview from './BookPreview';
 
-export default class BookOverview extends PureComponent {
+import Text from '../../../common-ui/Text';
+import Spacing from '../../../common-ui/Spacing';
+import withLoading from '../../../common-ui/withLoading';
+
+const LoadingMessage = (
+  <Spacing vertical={4} horizontal={2}>
+    <Text large>데이터를 불러들이고 있습니다.</Text>
+  </Spacing>
+);
+
+class BookOverview extends PureComponent {
   static propTypes = {
     myBookList: PropTypes.arrayOf(
       PropTypes.shape({
@@ -20,11 +30,13 @@ export default class BookOverview extends PureComponent {
     return (
       <React.Fragment>
         <InlineList spacingBetween={1}>
-          {myBookList.map(({ myBookId, book }) => (
-            <BookPreview name={book.name} cover={book.cover} id={myBookId} />
+          {myBookList.map((myBook, index) => (
+            <BookPreview myBook={myBook} key={index} />
           ))}
         </InlineList>
       </React.Fragment>
     );
   }
 }
+
+export default withLoading(LoadingMessage)(BookOverview);

--- a/s-with-me-front/src/components/student/libarary/BookPreview.jsx
+++ b/s-with-me-front/src/components/student/libarary/BookPreview.jsx
@@ -1,21 +1,37 @@
 import React, { PureComponent } from 'react';
-import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 
 import Card from '../../../common-ui/Card';
 import Button from '../../../common-ui/Button';
 import Heading from '../../../common-ui/Heading';
 import InlineList from '../../../common-ui/InlineList';
+import Api from '../../../Api';
 
 export default class BookPreview extends PureComponent {
-  static propTypes = {
-    id: PropTypes.number,
-    name: PropTypes.string.isRequired,
-    cover: PropTypes.node,
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      subject: '',
+      name: '',
+      cover: null,
+      grade: -1,
+    };
+  }
 
+  componentDidMount() {
+    const { myBook } = this.props;
+    Api.get('student/library/my-book', { params: { bookId: myBook.bookId } }).then(({ data }) =>
+      this.setState({
+        subject: data.subject,
+        name: data.name,
+        cover: data.cover,
+        grade: data.grade,
+      }),
+    );
+  }
   render() {
-    const { id, name, cover } = this.props;
+    const { myBook } = this.props;
+    const { subject, name, cover, grade } = this.state;
     return (
       <Card vertical={20} horizontal={4}>
         {cover}
@@ -23,11 +39,14 @@ export default class BookPreview extends PureComponent {
           삭제
         </Button>
         <Heading level={5}>{name}</Heading>
+        <Heading level={6}>
+          {grade}학년 / 과목:{subject}
+        </Heading>
         <InlineList spacingBetween={1}>
-          <Link to={`/library/myBook/${id}`}>
+          <Link to={`/library/myBook/${myBook.myBookId}`}>
             <Button xsmall>목차 보기</Button>
           </Link>
-          <Link to={`/library/myBook/${id}/solve`}>
+          <Link to={`/library/myBook/${myBook.myBookId}/solve`}>
             <Button xsmall>이어 풀기</Button>
           </Link>
         </InlineList>

--- a/s-with-me-front/src/components/student/libarary/LibraryApp.jsx
+++ b/s-with-me-front/src/components/student/libarary/LibraryApp.jsx
@@ -6,13 +6,10 @@ import AppNav, { HEIGHT } from '../AppNav';
 import LibraryFolderList from './LibraryFolderList';
 import BookOverview from './BookOverview';
 
-import Api from '../../../Api';
-
 class LibraryApp extends PureComponent {
   constructor(props) {
     super(props);
     this.state = {
-      myBookList: [],
       folders: [
         { id: 1, name: '2017' },
         { id: 2, name: '2018' },
@@ -20,17 +17,20 @@ class LibraryApp extends PureComponent {
     };
   }
 
+  static defaultProps = {
+    myBookList: [],
+    requestMyBookList: () => {},
+  };
+
   componentDidMount() {
-    Api.get('/student/library', { params: { studentId: 1 } }).then(response =>
-      this.setState({
-        myBookList: response.data.myBookList,
-      }),
-    );
+    // studentId 가져오기
+    const { requestMyBookList } = this.props;
+    requestMyBookList({ studentId: 1 });
   }
 
   render() {
-    const { styles } = this.props;
-    const { myBookList, folders } = this.state;
+    const { styles, myBookList, loading } = this.props;
+    const { folders } = this.state;
     return (
       <div {...css(styles.wrapper)}>
         <AppNav />
@@ -40,7 +40,7 @@ class LibraryApp extends PureComponent {
               <LibraryFolderList folders={folders} />
             </div>
             <div style={{ flex: 3, padding: 3 }}>
-              <BookOverview myBookList={myBookList} />
+              <BookOverview myBookList={myBookList} isLoading={loading} />
             </div>
             <div style={{ flex: 1, padding: 3 }}>이 달의 목표 ..</div>
           </div>

--- a/s-with-me-front/src/components/student/libarary/LibraryFolderFilter.jsx
+++ b/s-with-me-front/src/components/student/libarary/LibraryFolderFilter.jsx
@@ -8,13 +8,13 @@ import Button from '../../../common-ui/Button';
 export default class LibraryFolderFilter extends PureComponent {
   render() {
     return (
-      <Form onSubmit={values => console.log(values)}>
+      <Form onSubmit={(values) => console.log(values)}>
         <Form.Consumer>
           {({ onChange, values }) => (
             <InlineList spacingBetween={1}>
               {/* <Select name="libFilter" onChange={onChange} values={values['libFilter']}> */}
               <Select name="libFilter" onChange={onChange}>
-                <Option label="정렬 방식을 선택하세요" />
+                <Option label="정렬 방식을 선택하세요" value="" />
                 <Option label="과목별로 분류" value="subject" />
                 <Option label="폴더별로 분류" value="folder" />
                 <Option label="구입순으로 정렬" value="latest" />

--- a/s-with-me-front/src/components/student/problem/ProblemView.jsx
+++ b/s-with-me-front/src/components/student/problem/ProblemView.jsx
@@ -67,7 +67,7 @@ class ProblemView extends PureComponent {
 
   render() {
     const { myProblem, styles } = this.props;
-    const { myProblemId, myAnswer } = myProblem;
+    const { myProblemId, myAnswer, myBookId } = myProblem;
     const { isSolved, problemNum, content, isOptional, answer } = this.state;
     let optionContents = [];
     if (isOptional) {
@@ -108,7 +108,12 @@ class ProblemView extends PureComponent {
                 </div>
                 <div style={{ display: 'flex' }}>
                   <IsConfusedContainer id={myProblemId} />
-                  <ScoringButtonContainer id={myProblemId} answer={answer} myAnswer={myAnswer}>
+                  <ScoringButtonContainer
+                    id={myProblemId}
+                    answer={answer}
+                    myAnswer={myAnswer}
+                    myBookId={myBookId}
+                  >
                     개별 채점
                   </ScoringButtonContainer>
                 </div>

--- a/s-with-me-front/src/components/student/problem/ScoringButton.jsx
+++ b/s-with-me-front/src/components/student/problem/ScoringButton.jsx
@@ -24,10 +24,11 @@ export default class ScoringButton extends PureComponent {
   }
 
   handleScoringButtonClick(id, realAnswer, myAnswer, dateTime) {
-    const { setSolvedDateTime, setIsRight } = this.props;
+    const { setSolvedDateTime, setIsRight, myBookId, setLastMyProblem } = this.props;
     setSolvedDateTime(id, dateTime);
     if (realAnswer === myAnswer) setIsRight(id, true);
     else setIsRight(id, false);
+    setLastMyProblem(myBookId, id);
   }
   render() {
     const dateTime = this.state.date.getTime();

--- a/s-with-me-front/src/containers/student/book/LibraryAppContainer.jsx
+++ b/s-with-me-front/src/containers/student/book/LibraryAppContainer.jsx
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { requestMyBookList } from '../../../actions/myBookActions';
+import { requestMyBookList } from '../../../actions/myBookPackActions';
 import LibraryApp from '../../../components/student/libarary/LibraryApp';
 
 const mapStateToProps = (state) => {

--- a/s-with-me-front/src/containers/student/book/LibraryAppContainer.jsx
+++ b/s-with-me-front/src/containers/student/book/LibraryAppContainer.jsx
@@ -1,0 +1,16 @@
+import { connect } from 'react-redux';
+import { requestMyBookList } from '../../../actions/myBookActions';
+import LibraryApp from '../../../components/student/libarary/LibraryApp';
+
+const mapStateToProps = (state) => {
+  const { ids, entities, loading } = state.myBookList;
+  const myBookList = ids.map((id) => entities[id]);
+
+  return { myBookList, loading };
+};
+
+const mapDispatchToProps = {
+  requestMyBookList,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(LibraryApp);

--- a/s-with-me-front/src/containers/student/problem/ScoringButtonContainer.jsx
+++ b/s-with-me-front/src/containers/student/problem/ScoringButtonContainer.jsx
@@ -1,11 +1,13 @@
 import { connect } from 'react-redux';
 import { setSolvedDateTime, setIsRight } from '../../../actions/myProblemActions';
 import ScoringButton from '../../../components/student/problem/ScoringButton';
+import { setLastMyProblem } from '../../../actions/myBookActions';
 
 const mapDispatchToProps = dispatch => {
   return {
     setSolvedDateTime: (id, solvedDateTime) => dispatch(setSolvedDateTime(id, solvedDateTime)),
     setIsRight: (id, isRight) => dispatch(setIsRight(id, isRight)),
+    setLastMyProblem: (id, lastMyProblemId) => dispatch(setLastMyProblem(id, lastMyProblemId)),
   };
 };
 

--- a/s-with-me-front/src/middlewares/notificationEffects.js
+++ b/s-with-me-front/src/middlewares/notificationEffects.js
@@ -1,11 +1,12 @@
 import { SET_ERROR } from '../actions/myProblemActions';
 import { showMessage, SHOW_NOTIFICATION, hideMessage } from '../actions/notificationActions';
 import { debounce } from '../debounce';
+import { KEY, LIFECYCLE } from 'redux-pack';
 
-const debounceRunner = debounce((action) => action(), 4000);
+const debounceRunner = debounce(action => action(), 4000);
 
-export default (store) => (nextRunner) => (action) => {
-  const { type, payload } = action;
+export default store => nextRunner => action => {
+  const { type, payload, meta } = action;
   if (type === SET_ERROR) {
     const { errorMessage } = payload;
     store.dispatch(showMessage(errorMessage, true));
@@ -13,6 +14,15 @@ export default (store) => (nextRunner) => (action) => {
     const hide = () => store.dispatch(hideMessage());
     setTimeout(4000);
     debounceRunner(hide);
+  }
+
+  if (meta && meta.notification) {
+    const { success, error } = meta.notification;
+    if (success && meta[KEY.LIFECYCLE] === LIFECYCLE.SUCCESS) {
+      store.dispatch(showMessage(success));
+    } else if (error && meta[KEY.LIFECYCLE] === LIFECYCLE.FAILURE) {
+      store.dispatch(showMessage(error, true));
+    }
   }
   return nextRunner(action);
 };

--- a/s-with-me-front/src/reducers/index.js
+++ b/s-with-me-front/src/reducers/index.js
@@ -1,9 +1,11 @@
 import myProblemList from './myProblemReducers';
 import user from './userReducer';
 import notification from './notificationReducer';
+import myBookList from './myBookReducer';
 
 export default {
   myProblemList,
   user,
   notification,
+  myBookList,
 };

--- a/s-with-me-front/src/reducers/myBookReducer.js
+++ b/s-with-me-front/src/reducers/myBookReducer.js
@@ -1,0 +1,59 @@
+import {
+  LOADING_MY_BOOK_LIST,
+  SET_ERROR,
+  SET_MY_BOOK_LIST,
+  SET_LAST_MY_PROBLEM,
+} from '../actions/myBookActions';
+
+const initState = {
+  ids: [],
+  entities: {},
+  loading: false,
+  hasError: false,
+};
+
+export default (state = initState, action) => {
+  const { type, payload } = action;
+
+  switch (type) {
+    case SET_ERROR: {
+      const { errorMessage } = payload;
+      return {
+        ...state,
+        loading: false,
+        hasError: true,
+        errorMessage,
+      };
+    }
+    case LOADING_MY_BOOK_LIST: {
+      return {
+        ...state,
+        loading: true,
+        hasError: false,
+      };
+    }
+    case SET_MY_BOOK_LIST: {
+      const ids = payload.map((entity) => entity['myBookId']);
+      const entities = payload.reduce(
+        (finalEntities, entity) => ({
+          ...finalEntities,
+          [entity['myBookId']]: entity,
+        }),
+        {},
+      );
+      return { ...state, ids, entities, loading: false, hasError: false };
+    }
+    case SET_LAST_MY_PROBLEM: {
+      const { id, lastMyProblemId } = payload;
+      return {
+        ...state,
+        entities: {
+          ...state.entities,
+          [id]: { ...state.entities[id], lastMyProblemId },
+        },
+      };
+    }
+    default:
+      return state;
+  }
+};

--- a/s-with-me-front/src/reducers/myBookReducer.js
+++ b/s-with-me-front/src/reducers/myBookReducer.js
@@ -1,9 +1,7 @@
-import {
-  LOADING_MY_BOOK_LIST,
-  SET_ERROR,
-  SET_MY_BOOK_LIST,
-  SET_LAST_MY_PROBLEM,
-} from '../actions/myBookActions';
+import { SET_LAST_MY_PROBLEM } from '../actions/myBookActions';
+
+import { handle } from 'redux-pack';
+import { FETCH_MY_BOOK_LIST } from '../actions/myBookPackActions';
 
 const initState = {
   ids: [],
@@ -16,32 +14,35 @@ export default (state = initState, action) => {
   const { type, payload } = action;
 
   switch (type) {
-    case SET_ERROR: {
-      const { errorMessage } = payload;
-      return {
-        ...state,
-        loading: false,
-        hasError: true,
-        errorMessage,
-      };
-    }
-    case LOADING_MY_BOOK_LIST: {
-      return {
-        ...state,
-        loading: true,
-        hasError: false,
-      };
-    }
-    case SET_MY_BOOK_LIST: {
-      const ids = payload.map((entity) => entity['myBookId']);
-      const entities = payload.reduce(
-        (finalEntities, entity) => ({
-          ...finalEntities,
-          [entity['myBookId']]: entity,
+    case FETCH_MY_BOOK_LIST: {
+      return handle(state, action, {
+        start: (prevState) => ({
+          ...prevState,
+          loading: true,
+          hasError: false,
         }),
-        {},
-      );
-      return { ...state, ids, entities, loading: false, hasError: false };
+        success: (prevState) => {
+          const { data } = payload;
+          const ids = data.map((entity) => entity['myBookId']);
+          const entities = data.reduce(
+            (finalEntities, entity) => ({
+              ...finalEntities,
+              [entity['myBookId']]: entity,
+            }),
+            {},
+          );
+          return { ...prevState, ids, entities, loading: false, hasError: false };
+        },
+        failure: (prevState) => {
+          const { errorMessage } = payload.response.data;
+          return {
+            ...prevState,
+            loading: false,
+            hasError: true,
+            errorMessage,
+          };
+        },
+      });
     }
     case SET_LAST_MY_PROBLEM: {
       const { id, lastMyProblemId } = payload;

--- a/s-with-me-front/src/store/configureStore.js
+++ b/s-with-me-front/src/store/configureStore.js
@@ -1,14 +1,17 @@
 import { createStore, combineReducers, applyMiddleware } from 'redux';
 import { composeWithDevTools } from 'redux-devtools-extension';
 import thunk from 'redux-thunk';
+import { middleware as reduxPackMiddleware } from 'redux-pack';
 
 import reducers from '../reducers';
 import notificationEffects from '../middlewares/notificationEffects';
 import myProblemEffects from '../middlewares/myProblemEffects';
 
-export default (initStates) =>
+export default initStates =>
   createStore(
     combineReducers(reducers),
     initStates,
-    composeWithDevTools(applyMiddleware(thunk, notificationEffects, myProblemEffects)),
+    composeWithDevTools(
+      applyMiddleware(thunk, reduxPackMiddleware, notificationEffects, myProblemEffects),
+    ),
   );


### PR DESCRIPTION
~Problem과 마찬가지로~  (redux-pack쓰면 코드 길이도 짧아지고 훨씬 더 직관적이어서 조금 수정했습니다.)
서버에서 데이터 불러와서 myBookList state로 만들었습니다.
myBook의 bookId로 book정보도 불러와서 연결했고, 각각 국어 문제 누르면 국어 문제 푸는 페이지, 수학 누르면 수학 문제 페이지로 연결됩니다.

현재 채점 될 때마다 lastMyProblem은 프론트에서 업데이트해서 가지고 있도록 만들었는데 채점 누를 때 마다 서버에 보내는 것 보다 최종적으로 문제집 닫기 버튼을 클릭할 때 최종 lastMyProblemId를 업데이트해서 서버에 보내면 될 것 같습니다!

@KimSeongKyu @JungH00ns 
- 나중에 lastProblemId 수정(put)하는 Api 만들어야 합니다.

@ssoheej 
- 프론트에서는 이어풀기 누르면 문제풀기 페이지로 연결되도록 하고, 문제풀고 채점 버튼 눌렀을때 lastProblemId가 업데이트 되도록 해야합니다.

++ 다음은 페이지 이동하는거 공부해보겠습니동 ㅠ.ㅠ