### PR TITLE
학생 서재 폴더별 분류 + 내 문제집 삭제

### DIFF
--- a/s-with-me-back/src/main/java/com/swithme/service/MyBookService.java
+++ b/s-with-me-back/src/main/java/com/swithme/service/MyBookService.java
@@ -82,4 +82,22 @@ public class MyBookService {
         }
         return responseDtoList;
     }
+
+    @Transactional
+    public List<MyBookResponseDto> findMyBookListFilteredByFolder(int folderId) {
+        Folder folder = folderRepository.findById(folderId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 폴더가 없습니다. folderId = " + folderId));
+        List<MyBook> myBookList = myBookRepository.findByFolder(folder);
+        List<MyBookResponseDto> responseDtoList = new ArrayList<>();
+        for(MyBook myBook : myBookList){
+            responseDtoList.add(MyBookResponseDto.builder()
+                    .myBookId(myBook.getMyBookId())
+                    .bookId(myBook.getBook().getBookId())
+                    .folderId(myBook.getFolder().getFolderId())
+                    .lastSubChapterId(myBook.getLastSubChapterId())
+                    .lastPageNumber(myBook.getLastPageNumber())
+                    .build());
+        }
+        return responseDtoList;
+    }
 }

--- a/s-with-me-back/src/main/java/com/swithme/service/MyBookService.java
+++ b/s-with-me-back/src/main/java/com/swithme/service/MyBookService.java
@@ -6,12 +6,13 @@ import com.swithme.domain.folder.Folder;
 import com.swithme.domain.folder.FolderRepository;
 import com.swithme.domain.myBook.MyBook;
 import com.swithme.domain.myBook.MyBookRepository;
+import com.swithme.domain.myProblem.MyProblem;
+import com.swithme.domain.myProblem.MyProblemRepository;
+import com.swithme.domain.note.Note;
+import com.swithme.domain.note.NoteRepository;
 import com.swithme.domain.student.Student;
 import com.swithme.domain.student.StudentRepository;
-import com.swithme.web.dto.MyBookCreateDto;
-import com.swithme.web.dto.MyBookResponseDto;
-import com.swithme.web.dto.MyBookUpdateRequestDto;
-import com.swithme.web.dto.MybookFolderUpdateRequestDto;
+import com.swithme.web.dto.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,6 +28,8 @@ public class MyBookService {
     private final FolderRepository folderRepository;
     private final BookRepository bookRepository;
     private final StudentRepository studentRepository;
+    private final MyProblemRepository myProblemRepository;
+    private final NoteRepository noteRepository;
 
     @Transactional
     public String bringUpToDate(int myBookId, MyBookUpdateRequestDto requestDto) {
@@ -99,5 +102,22 @@ public class MyBookService {
                     .build());
         }
         return responseDtoList;
+    }
+
+    @Transactional
+    public String deleteMyBook(int myBookId) {
+        MyBook myBook = myBookRepository.findById(myBookId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 myBook이 없습니다. myBookId = " + myBookId));
+        String myBookName = myBook.getBook().getName();
+        List<MyProblem> myProblemList = myProblemRepository.findByMyBook(myBook);
+        for(MyProblem myProblem : myProblemList){
+            if(noteRepository.findByMyProblem(myProblem) != null){
+                noteRepository.delete(noteRepository.findByMyProblem(myProblem));
+            }
+            myProblemRepository.delete(myProblem);
+        }
+        myBookRepository.delete(myBook);
+
+        return myBookName + " 문제집과 그에 관련된 문제, 오답노트가 삭제되었습니다.";
     }
 }

--- a/s-with-me-back/src/main/java/com/swithme/web/controller/MyBookController.java
+++ b/s-with-me-back/src/main/java/com/swithme/web/controller/MyBookController.java
@@ -1,6 +1,5 @@
 package com.swithme.web.controller;
 
-import com.swithme.domain.myBook.MyBook;
 import com.swithme.domain.myBook.MyBookRepository;
 import com.swithme.service.MyBookService;
 import com.swithme.web.dto.MyBookCreateDto;
@@ -58,5 +57,11 @@ public class MyBookController {
     public int updateFolder(@PathVariable int myBookId,
                             @RequestBody MybookFolderUpdateRequestDto requestDto){
         return myBookService.updateFolder(myBookId, requestDto);
+    }
+
+    @CrossOrigin
+    @DeleteMapping("/student/library/my-book/{myBookId}")
+    public String deleteMyBook(@PathVariable int myBookId){
+        return myBookService.deleteMyBook(myBookId);
     }
 }

--- a/s-with-me-back/src/main/java/com/swithme/web/controller/MyBookController.java
+++ b/s-with-me-back/src/main/java/com/swithme/web/controller/MyBookController.java
@@ -35,6 +35,12 @@ public class MyBookController {
     }
 
     @CrossOrigin
+    @GetMapping("/student/library/my-book/folderFilter")
+    public List<MyBookResponseDto> getMyBookListFilteredByFolder(@RequestParam("folderId") int folderId){
+        return myBookService.findMyBookListFilteredByFolder(folderId);
+    }
+
+    @CrossOrigin
     @PostMapping("/student/library/my-book")
     public String createMyBook(@RequestBody MyBookCreateDto myBookCreateDto){
         return myBookService.createMyBook(myBookCreateDto);

--- a/s-with-me-back/src/main/java/com/swithme/web/controller/ProblemController.java
+++ b/s-with-me-back/src/main/java/com/swithme/web/controller/ProblemController.java
@@ -21,8 +21,8 @@ public class ProblemController {
     }
 
     @CrossOrigin
-    @GetMapping("/publisher/library/book/mainChapter/subChapter/{subChapterId}")
-    public List<ProblemResponseDto> getProblemList(@PathVariable int subChapterId){
+    @GetMapping("/publisher/library/book/mainChapter")
+    public List<ProblemResponseDto> getProblemList(@RequestParam("subChapterId") int subChapterId){
         return problemService.getProblemList(subChapterId);
     }
 

--- a/s-with-me-back/src/test/java/com/swithme/web/controller/MyBookControllerTest.java
+++ b/s-with-me-back/src/test/java/com/swithme/web/controller/MyBookControllerTest.java
@@ -2,6 +2,8 @@ package com.swithme.web.controller;
 
 import com.swithme.domain.book.Book;
 import com.swithme.domain.book.BookRepository;
+import com.swithme.domain.folder.Folder;
+import com.swithme.domain.folder.FolderRepository;
 import com.swithme.domain.myBook.MyBook;
 import com.swithme.domain.myBook.MyBookRepository;
 import com.swithme.domain.student.Student;
@@ -37,6 +39,10 @@ public class MyBookControllerTest {
     private BookRepository bookRepository;
     @Autowired
     private StudentRepository studentRepository;
+    @Autowired
+    private FolderRepository folderRepository;
+
+    private Folder folder;
 
     @Before
     public void setup(){
@@ -45,8 +51,12 @@ public class MyBookControllerTest {
         bookRepository.save(new Book());
         Book book = bookRepository.findAll().get(0);
 
+        folderRepository.save(new Folder());
+        folder = folderRepository.findAll().get(0);
+
         myBookRepository.save(MyBook.builder()
                 .book(book)
+                .folder(folder)
                 .build());
     }
 
@@ -81,6 +91,15 @@ public class MyBookControllerTest {
         Student student = studentRepository.findAll().get(0);
 
         String url = "http://localhost:" + port + "/student/library?studentId=" + student.getStudentId();
+        ResponseEntity<String> responseEntity = restTemplate.getForEntity(url, String.class);
+
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    public void getMyBookListFilteredByFolder(){
+        String url = "http://localhost:" + port + "/student/library/my-book/folderFilter?folderId=" + folder.getFolderId();
+
         ResponseEntity<String> responseEntity = restTemplate.getForEntity(url, String.class);
 
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);

--- a/s-with-me-back/src/test/java/com/swithme/web/controller/MyBookControllerTest.java
+++ b/s-with-me-back/src/test/java/com/swithme/web/controller/MyBookControllerTest.java
@@ -6,6 +6,10 @@ import com.swithme.domain.folder.Folder;
 import com.swithme.domain.folder.FolderRepository;
 import com.swithme.domain.myBook.MyBook;
 import com.swithme.domain.myBook.MyBookRepository;
+import com.swithme.domain.myProblem.MyProblem;
+import com.swithme.domain.myProblem.MyProblemRepository;
+import com.swithme.domain.note.Note;
+import com.swithme.domain.note.NoteRepository;
 import com.swithme.domain.student.Student;
 import com.swithme.domain.student.StudentRepository;
 import com.swithme.web.dto.MyBookUpdateRequestDto;
@@ -20,6 +24,7 @@ import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.*;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import javax.net.ssl.HttpsURLConnection;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,6 +46,10 @@ public class MyBookControllerTest {
     private StudentRepository studentRepository;
     @Autowired
     private FolderRepository folderRepository;
+    @Autowired
+    private MyProblemRepository myProblemRepository;
+    @Autowired
+    private NoteRepository noteRepository;
 
     private Folder folder;
 
@@ -103,5 +112,33 @@ public class MyBookControllerTest {
         ResponseEntity<String> responseEntity = restTemplate.getForEntity(url, String.class);
 
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    public void deleteMyBookTest(){
+        MyBook myBook = myBookRepository.findAll().get(0);
+
+        myProblemRepository.save(MyProblem.builder()
+                .myBook(myBook)
+                .build());
+        MyProblem myProblem = myProblemRepository.findAll().get(0);
+
+        noteRepository.save(Note.builder()
+                .myProblem(myProblem)
+                .build());
+
+        assertThat(myBookRepository.findAll()).isNotEmpty();
+        assertThat(myProblemRepository.findAll()).isNotEmpty();
+        assertThat(noteRepository.findAll()).isNotEmpty();
+
+        HttpHeaders headers = new HttpHeaders();
+        HttpEntity<HttpHeaders> entity = new HttpEntity<>(headers);
+        String url = "http://localhost:" + port + "/student/library/my-book/" + myBook.getMyBookId();
+        ResponseEntity<String> responseEntity = restTemplate.exchange(url, HttpMethod.DELETE, entity, String.class);
+
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(myBookRepository.findAll()).isEmpty();
+        assertThat(myProblemRepository.findAll()).isEmpty();
+        assertThat(noteRepository.findAll()).isEmpty();
     }
 }

--- a/s-with-me-back/src/test/java/com/swithme/web/controller/ProblemControllerTest.java
+++ b/s-with-me-back/src/test/java/com/swithme/web/controller/ProblemControllerTest.java
@@ -71,7 +71,7 @@ public class ProblemControllerTest {
         problemRepository.save(Problem.builder()
                 .subChapter(subChapter)
                 .build());
-        String url = "http://localhost:" + port + "/publisher/library/book/mainChapter/subChapter/"
+        String url = "http://localhost:" + port + "/publisher/library/book/mainChapter?subChapterId="
                  + subChapter.getSubChapterId();
         ResponseEntity<String> responseEntity = restTemplate.getForEntity(url, String.class);
 


### PR DESCRIPTION
1. 출판사의 문제 리스트 가져오는 API의 parameter 방식을 pathvariable에서 requestparam으로 수정
2. 학생의 myBookList을 폴더별로 필터링해서 가져오는 API 추가
3. 학생의 내 문제집, 내 문제, 오답노트 삭제 API 추가